### PR TITLE
fix: enable rawLeaves

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -161,7 +161,8 @@ export async function fileListToCarIterator (fileList, blockApi = new MapBlockSt
   
   const options = {
     cidVersion: 1,
-    wrapWithDirectory: true
+    wrapWithDirectory: true,
+    rawLeaves: true
   }
   const unixFsEntries = []
   for await (const entry of importer(fileEntries, blockApi, options)) {


### PR DESCRIPTION
For parity with IPFS when using CIDv1.